### PR TITLE
Fix compatibility with redcarpet 3.1.1

### DIFF
--- a/lib/ultra_markdown/markdown_processor.rb
+++ b/lib/ultra_markdown/markdown_processor.rb
@@ -66,7 +66,7 @@ module Redcarpet
       end
 
       # Topic 裡面，所有的 head 改為 h2 顯示
-      def header(text, header_level)
+      def header(text, header_level, anchor = nil)
         header_level += 1
         "<h#{header_level}>#{text}</h#{header_level}>"
       end


### PR DESCRIPTION
The `header` callback is called with 3 arguments since redcarpet 3.1.0.

This pull request fixes the compatibility issue by adding the `anchor` argument defaulting to `nil`.
